### PR TITLE
12.1.3 - Implement authentication login token handling route guards

### DIFF
--- a/admin-frontend/src/App.tsx
+++ b/admin-frontend/src/App.tsx
@@ -1,0 +1,5 @@
+import AppRouter from "./routes/AppRouter";
+
+export default function App() {
+  return <AppRouter />;
+}

--- a/admin-frontend/src/components/auth/LoginForm.tsx
+++ b/admin-frontend/src/components/auth/LoginForm.tsx
@@ -39,7 +39,7 @@ export default function LoginForm({
       />
 
       {error && (
-        <div className="rounded-md bg-semantic-error/10 px-3 py-2 text-sm text-semantic-error">
+        <div className="rounded-md px-3 py-2 text-sm text-semantic-error" style={{ backgroundColor: "var(--semantic-error, #f00)", opacity: 0.1 }}>
           {error}
         </div>
       )}

--- a/admin-frontend/src/components/auth/LoginForm.tsx
+++ b/admin-frontend/src/components/auth/LoginForm.tsx
@@ -47,7 +47,7 @@ export default function LoginForm({
       <Button
         type="submit"
         loading={loading}
-        className="mt-2 w-full bg-brand-primary text-white hover:bg-blue-700"
+        className="mt-2 w-full bg-brand-primary text-white hover:bg-brand-primary-dark"
       >
         Sign in
       </Button>

--- a/admin-frontend/src/components/auth/LoginForm.tsx
+++ b/admin-frontend/src/components/auth/LoginForm.tsx
@@ -1,0 +1,56 @@
+// UI for login form
+
+import Input from "@frontend/common/src/components/form/Input";
+import Button from "@frontend/common/src/components/Button";
+
+type LoginFormProps = {
+  username: string;
+  password: string;
+  error?: string | null;
+  loading?: boolean;
+  onUsernameChange: (v: string) => void;
+  onPasswordChange: (v: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+};
+
+export default function LoginForm({
+  username,
+  password,
+  error,
+  loading,
+  onUsernameChange,
+  onPasswordChange,
+  onSubmit,
+}: LoginFormProps) {
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-3">
+      <Input
+        placeholder="Username"
+        autoComplete="username"
+        value={username}
+        onChange={(e) => onUsernameChange(e.target.value)}
+      />
+      <Input
+        type="password"
+        placeholder="Password"
+        autoComplete="current-password"
+        value={password}
+        onChange={(e) => onPasswordChange(e.target.value)}
+      />
+
+      {error && (
+        <div className="rounded-md bg-semantic-error/10 px-3 py-2 text-sm text-semantic-error">
+          {error}
+        </div>
+      )}
+
+      <Button
+        type="submit"
+        loading={loading}
+        className="mt-2 w-full bg-brand-primary text-white hover:bg-blue-700"
+      >
+        Sign in
+      </Button>
+    </form>
+  );
+}

--- a/admin-frontend/src/components/auth/LoginFormContainer.tsx
+++ b/admin-frontend/src/components/auth/LoginFormContainer.tsx
@@ -1,0 +1,40 @@
+// Logic (hooks + state) for login form
+
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@frontend/common";
+import LoginForm from "./LoginForm";
+
+export default function LoginFormContainer() {
+  const { login } = useAuth();
+  const nav = useNavigate();
+  const [form, setForm] = useState({ username: "", password: "" });
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      await login(form.username.trim(), form.password);
+      nav("/dashboard", { replace: true });
+    } catch (err: any) {
+      setError(err?.message || "Login failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <LoginForm
+      username={form.username}
+      password={form.password}
+      error={error}
+      loading={loading}
+      onUsernameChange={(v) => setForm((s) => ({ ...s, username: v }))}
+      onPasswordChange={(v) => setForm((s) => ({ ...s, password: v }))}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/admin-frontend/src/components/auth/LoginFormContainer.tsx
+++ b/admin-frontend/src/components/auth/LoginFormContainer.tsx
@@ -18,7 +18,7 @@ export default function LoginFormContainer() {
     setLoading(true);
     try {
       await login(form.username.trim(), form.password);
-      nav("/dashboard", { replace: true });
+      nav("/", { replace: true });
     } catch (err: any) {
       setError(err?.message || "Login failed");
     } finally {

--- a/admin-frontend/src/components/layout/AdminLayout.tsx
+++ b/admin-frontend/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,13 @@
+import TopNav from "./TopNav";
+import { Outlet } from "react-router-dom";
+
+export default function AdminLayout() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <TopNav />
+      <main className="mx-auto max-w-screen-2xl px-4 py-6">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/admin-frontend/src/components/layout/TopNav.tsx
+++ b/admin-frontend/src/components/layout/TopNav.tsx
@@ -28,7 +28,7 @@ export default function TopNav() {
     <header className="sticky top-0 z-30 border-b bg-white">
       <div className="mx-auto flex max-w-screen-2xl items-center justify-between px-4 py-3">
         {/* Left: logo + brand */}
-        <NavItem to="/dashboard">
+        <NavItem to="/">
           <div className="flex items-center gap-3">
             <span className="text-base font-semibold text-gray-900">
               logivance 🚛
@@ -38,11 +38,10 @@ export default function TopNav() {
 
         {/* Desktop nav */}
         <nav className="hidden items-center gap-1 md:flex">
-          <NavItem to="/dashboard">Dashboard</NavItem>
+          <NavItem to="/">Dashboard</NavItem>
           <NavItem to="/shipments">Shipments</NavItem>
           <NavItem to="/customers">Customers</NavItem>
-          <NavItem to="/vehicles">Vehicles</NavItem>
-          <NavItem to="/alerts">Alerts</NavItem>
+          <NavItem to="/notifications">Notifications</NavItem>
         </nav>
 
         {/* Right: user menu */}
@@ -75,7 +74,7 @@ export default function TopNav() {
       {open && (
         <div className="border-t bg-white px-4 py-2 md:hidden">
           <div className="flex flex-col gap-1">
-            <NavItem to="/dashboard">Dashboard</NavItem>
+            <NavItem to="/">Dashboard</NavItem>
             <NavItem to="/shipments">Shipments</NavItem>
             <NavItem to="/customers">Customers</NavItem>
             <NavItem to="/notifications">Notifications</NavItem>

--- a/admin-frontend/src/components/layout/TopNav.tsx
+++ b/admin-frontend/src/components/layout/TopNav.tsx
@@ -1,0 +1,97 @@
+import { NavLink, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { useAuth } from "@frontend/common";
+
+function NavItem({ to, children }: { to: string; children: React.ReactNode }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `rounded-md px-3 py-2 text-sm font-medium ${
+          isActive
+            ? "bg-blue-50 text-blue-700"
+            : "text-gray-700 hover:bg-gray-50"
+        }`
+      }
+    >
+      {children}
+    </NavLink>
+  );
+}
+
+export default function TopNav() {
+  const [open, setOpen] = useState(false);
+  const { user, logout } = useAuth();
+  const nav = useNavigate();
+
+  return (
+    <header className="sticky top-0 z-30 border-b bg-white">
+      <div className="mx-auto flex max-w-screen-2xl items-center justify-between px-4 py-3">
+        {/* Left: logo + brand */}
+        <NavItem to="/dashboard">
+          <div className="flex items-center gap-3">
+            <span className="text-base font-semibold text-gray-900">
+              logivance 🚛
+            </span>
+          </div>
+        </NavItem>
+
+        {/* Desktop nav */}
+        <nav className="hidden items-center gap-1 md:flex">
+          <NavItem to="/dashboard">Dashboard</NavItem>
+          <NavItem to="/shipments">Shipments</NavItem>
+          <NavItem to="/customers">Customers</NavItem>
+          <NavItem to="/vehicles">Vehicles</NavItem>
+          <NavItem to="/alerts">Alerts</NavItem>
+        </nav>
+
+        {/* Right: user menu */}
+        <div className="hidden items-center gap-3 md:flex">
+          <span className="text-sm text-gray-600">
+            {user?.email ?? "Signed in"}
+          </span>
+          <button
+            onClick={() => {
+              logout();
+              nav("/login", { replace: true });
+            }}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-gray-50"
+          >
+            Sign out
+          </button>
+        </div>
+
+        {/* Mobile menu button */}
+        <button
+          className="inline-flex items-center rounded-md border px-2 py-1.5 md:hidden"
+          onClick={() => setOpen((o) => !o)}
+          aria-label="Toggle navigation"
+        >
+          ☰
+        </button>
+      </div>
+
+      {/* Mobile nav panel */}
+      {open && (
+        <div className="border-t bg-white px-4 py-2 md:hidden">
+          <div className="flex flex-col gap-1">
+            <NavItem to="/dashboard">Dashboard</NavItem>
+            <NavItem to="/shipments">Shipments</NavItem>
+            <NavItem to="/customers">Customers</NavItem>
+            <NavItem to="/notifications">Notifications</NavItem>
+            <button
+              className="mt-2 rounded-md border px-3 py-2 text-left text-sm hover:bg-gray-50"
+              onClick={() => {
+                logout();
+                setOpen(false);
+                nav("/login", { replace: true });
+              }}
+            >
+              Sign out
+            </button>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/admin-frontend/src/index.css
+++ b/admin-frontend/src/index.css
@@ -1,14 +1,13 @@
 @import "tailwindcss";
 
-:root {
+body {
+  @apply bg-gray-50 text-gray-900 antialiased;
+
+  margin: 0;
+  padding: 0;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -16,53 +15,9 @@
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  @apply text-blue-600 hover:text-blue-700 underline;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  @apply rounded-lg px-4 py-2 font-medium transition-colors;
 }

--- a/admin-frontend/src/lib/env.ts
+++ b/admin-frontend/src/lib/env.ts
@@ -1,0 +1,6 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+if (!API_BASE_URL) {
+  // Optional: warn in dev
+  // eslint-disable-next-line no-console
+  console.warn("VITE_API_BASE_URL is not set");
+}

--- a/admin-frontend/src/main.tsx
+++ b/admin-frontend/src/main.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import AppRouter from "./routes/AppRouter";
 import "./index.css";
+import App from "./App";
+
+// set common base URL getter
+import { setBaseUrlGetter } from "@frontend/common";
+import { API_BASE_URL } from "./lib/env";
+setBaseUrlGetter(() => API_BASE_URL);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <AppRouter />
+    <App />
   </React.StrictMode>
 );

--- a/admin-frontend/src/pages/DashboardPage.tsx
+++ b/admin-frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const DashboardPage: React.FC = () => {
+  return <div className="p-6 space-y-4">Dashboard</div>;
+};
+
+export default DashboardPage;

--- a/admin-frontend/src/pages/HomePage.tsx
+++ b/admin-frontend/src/pages/HomePage.tsx
@@ -1,7 +1,0 @@
-export default function HomePage() {
-  return (
-    <div className="text-center">
-      <h1>This is the homepage</h1>
-    </div>
-  );
-}

--- a/admin-frontend/src/pages/LoginPage.tsx
+++ b/admin-frontend/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import Button from "@frontend/common/src/components/Button";
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-grey-50 px-4">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
       <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow">
         <h1 className="mb-1 text-center text-2xl font-semibold text-gray-800">
           logivance 🚛

--- a/admin-frontend/src/pages/LoginPage.tsx
+++ b/admin-frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import LoginFormContainer from "../components/auth/LoginFormContainer";
-import Button from "../../../common/src/components/Button";
+import Button from "@frontend/common/src/components/Button";
 
 export default function LoginPage() {
   return (

--- a/admin-frontend/src/pages/LoginPage.tsx
+++ b/admin-frontend/src/pages/LoginPage.tsx
@@ -1,29 +1,17 @@
-// Log in example page
+import LoginFormContainer from "../components/auth/LoginFormContainer";
+import Button from "../../../common/src/components/Button";
+
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-sm rounded-xl bg-white p-8 shadow-md">
-        <h1 className="mb-6 text-center text-2xl font-semibold text-gray-800">
-          Sign in to your account
+    <div className="flex min-h-screen items-center justify-center bg-grey-50 px-4">
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow">
+        <h1 className="mb-1 text-center text-2xl font-semibold text-gray-800">
+          logivance 🚛
         </h1>
-        <form className="flex flex-col gap-4">
-          <input
-            type="text"
-            placeholder="Username"
-            className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none"
-          />
-          <input
-            type="password"
-            placeholder="Password"
-            className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none"
-          />
-          <button
-            type="submit"
-            className="mt-4 w-full rounded-lg bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-          >
-            Log in
-          </button>
-        </form>
+        <p className="mb-6 text-center text-sm text-gray-500">
+          Sign in to the administration panel.
+        </p>
+        <LoginFormContainer />
       </div>
     </div>
   );

--- a/admin-frontend/src/routes/AppRouter.tsx
+++ b/admin-frontend/src/routes/AppRouter.tsx
@@ -1,23 +1,46 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import HealthPage from "../pages/HealthPage";
-import HomePage from "../pages/HomePage";
+import { AuthProvider, ProtectedRoute } from "@frontend/common";
 import LoginPage from "../pages/LoginPage";
+import HealthPage from "../pages/HealthPage";
+import AdminLayout from "../components/layout/AdminLayout";
+import DashboardPage from "../pages/DashboardPage";
 
 const router = createBrowserRouter([
+  { path: "/login", element: <LoginPage /> },
+  { path: "/health", element: <HealthPage /> },
+
   {
-    path: "/",
-    element: <HomePage />,
-  },
-  {
-    path: "/login",
-    element: <LoginPage />,
-  },
-  {
-    path: "/health",
-    element: <HealthPage />,
+    element: <ProtectedRoute redirectTo="/login" />,
+    children: [
+      {
+        element: <AdminLayout />,
+        children: [
+          {
+            path: "/dashboard",
+            element: <DashboardPage />,
+          },
+          {
+            path: "/shipments",
+            element: <div className="p-4">Customers (WIP)</div>,
+          },
+          {
+            path: "/customers",
+            element: <div className="p-4">Customers (WIP)</div>,
+          },
+          {
+            path: "/notifications",
+            element: <div className="p-4">Notifications (WIP)</div>,
+          },
+        ],
+      },
+    ],
   },
 ]);
 
 export default function AppRouter() {
-  return <RouterProvider router={router} />;
+  return (
+    <AuthProvider storageKey="admin_auth">
+      <RouterProvider router={router} />
+    </AuthProvider>
+  );
 }

--- a/admin-frontend/src/routes/AppRouter.tsx
+++ b/admin-frontend/src/routes/AppRouter.tsx
@@ -21,7 +21,7 @@ const router = createBrowserRouter([
           },
           {
             path: "/shipments",
-            element: <div className="p-4">Customers (WIP)</div>,
+            element: <div className="p-4">Shipments (WIP)</div>,
           },
           {
             path: "/customers",

--- a/admin-frontend/src/routes/AppRouter.tsx
+++ b/admin-frontend/src/routes/AppRouter.tsx
@@ -16,7 +16,7 @@ const router = createBrowserRouter([
         element: <AdminLayout />,
         children: [
           {
-            path: "/dashboard",
+            path: "/",
             element: <DashboardPage />,
           },
           {

--- a/admin-frontend/tsconfig.app.json
+++ b/admin-frontend/tsconfig.app.json
@@ -1,26 +1,9 @@
 {
+  "extends": ".././tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "jsx": "react-jsx",
-
-    "strict": true,
-    "noEmit": true,
-    "isolatedModules": true,
-
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "outDir": "dist",
+    "rootDir": "."
   },
-  "include": ["src", "src/env.d.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src", "../common/src/**/*"],
+  "references": [{ "path": "../common" }]
 }

--- a/admin-frontend/tsconfig.node.json
+++ b/admin-frontend/tsconfig.node.json
@@ -1,17 +1,9 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-
     "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "types": ["node", "vite/client"],
-
-    "strict": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true
+    "moduleResolution": "Bundler"
   },
-  "include": ["vite.config.ts", "tailwind.config.ts", "postcss.config.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["vite.config.ts"]
 }

--- a/common/mock-data/db.json
+++ b/common/mock-data/db.json
@@ -1,0 +1,97 @@
+{
+  "customers": [
+    {
+      "id": "c1",
+      "name": "Alice Transport AB",
+      "email": "alice.sender@example.com",
+      "phone": "+46700000001",
+      "created_at": "2025-09-01T10:00:00Z"
+    },
+    {
+      "id": "c2",
+      "name": "Bob Retail",
+      "email": "bob.receiver@example.com",
+      "phone": "+46700000002",
+      "created_at": "2025-09-01T10:05:00Z"
+    }
+  ],
+  "drivers": [
+    {
+      "id": "d1",
+      "name": "Charlie Driver",
+      "email": "charlie.driver@example.com",
+      "phone": "+46700000003",
+      "assigned_vehicle": "veh1",
+      "created_at": "2025-09-01T10:10:00Z"
+    }
+  ],
+  "admins": [
+    {
+      "id": "a1",
+      "name": "Dana Admin",
+      "email": "admin@example.com",
+      "phone": "+46700000004",
+      "created_at": "2025-09-01T10:15:00Z"
+    }
+  ],
+  "vehicles": [
+    {
+      "id": "veh1",
+      "name": "Truck 12",
+      "plate": "ABC123",
+      "current_driver_id": "d1",
+      "last_heartbeat": "2025-09-05T08:00:00Z"
+    }
+  ],
+  "shipments": [
+    {
+      "id": "shp1",
+      "external_ref": "ORDER-7788",
+      "sender_id": "c1",
+      "receiver_id": "c2",
+      "status": "IN_TRANSIT",
+      "vehicle_id": "veh1",
+      "constraints": { "min_temp": 2, "max_temp": 8, "max_humidity": 85 },
+      "label": {
+        "qr": "qr-shp1-payload",
+        "barcode": "barcode-shp1"
+      },
+      "last_seen": { "lat": 59.3, "lon": 18.1, "at": "2025-09-05T08:10:00Z" },
+      "last_telemetry": { "temp": 6.2, "rh": 72, "at": "2025-09-05T08:10:00Z" },
+      "created_at": "2025-09-01T12:00:00Z"
+    }
+  ],
+  "telemetry": [
+    {
+      "id": "t1",
+      "shipment_id": "shp1",
+      "sensor_id": "sn1",
+      "at": "2025-09-05T08:05:00Z",
+      "temp": 6.1,
+      "rh": 73,
+      "lat": 59.3,
+      "lon": 18.1
+    },
+    {
+      "id": "t2",
+      "shipment_id": "shp1",
+      "sensor_id": "sn1",
+      "at": "2025-09-05T08:10:00Z",
+      "temp": 6.2,
+      "rh": 72,
+      "lat": 59.31,
+      "lon": 18.11
+    }
+  ],
+  "alerts": [
+    {
+      "id": "a1",
+      "shipment_id": "shp1",
+      "type": "TEMP_HIGH",
+      "severity": "WARN",
+      "at": "2025-09-05T08:12:00Z",
+      "resolved": false,
+      "resolved_at": null
+    }
+  ]
+}

--- a/common/package.json
+++ b/common/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@frontend/common",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/common/src/components/Button.tsx
+++ b/common/src/components/Button.tsx
@@ -1,0 +1,70 @@
+import clsx from "clsx";
+
+type Variant = "primary" | "secondary" | "danger" | "success" | "warning";
+type Appearance = "filled" | "outline" | "ghost";
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  loading?: boolean;
+  variant?: Variant;
+  appearance?: Appearance;
+};
+
+export default function Button({
+  loading,
+  variant = "primary",
+  appearance = "filled",
+  className,
+  children,
+  ...rest
+}: Props) {
+  const baseStyles =
+    "rounded-lg px-4 py-2 font-medium transition-colors disabled:opacity-60";
+
+  const variantMap: Record<
+    Variant,
+    { filled: string; outline: string; ghost: string }
+  > = {
+    primary: {
+      filled: "bg-blue-600 text-white hover:bg-blue-700",
+      outline:
+        "border border-blue-600 text-blue-600 bg-transparent hover:bg-blue-50",
+      ghost: "text-blue-600 bg-transparent hover:bg-blue-50",
+    },
+    secondary: {
+      filled: "bg-gray-600 text-white hover:bg-gray-700",
+      outline:
+        "border border-gray-600 text-gray-600 bg-transparent hover:bg-gray-50",
+      ghost: "text-gray-600 bg-transparent hover:bg-gray-50",
+    },
+    danger: {
+      filled: "bg-red-600 text-white hover:bg-red-700",
+      outline:
+        "border border-red-600 text-red-600 bg-transparent hover:bg-red-50",
+      ghost: "text-red-600 bg-transparent hover:bg-red-50",
+    },
+    success: {
+      filled: "bg-green-600 text-white hover:bg-green-700",
+      outline:
+        "border border-green-600 text-green-600 bg-transparent hover:bg-green-50",
+      ghost: "text-green-600 bg-transparent hover:bg-green-50",
+    },
+    warning: {
+      filled: "bg-amber-500 text-white hover:bg-amber-600",
+      outline:
+        "border border-amber-500 text-amber-500 bg-transparent hover:bg-amber-50",
+      ghost: "text-amber-500 bg-transparent hover:bg-amber-50",
+    },
+  };
+
+  const styles = variantMap[variant][appearance];
+
+  return (
+    <button
+      className={clsx(baseStyles, styles, className)}
+      disabled={loading || rest.disabled}
+      {...rest}
+    >
+      {loading ? "Loading…" : children}
+    </button>
+  );
+}

--- a/common/src/components/Card.tsx
+++ b/common/src/components/Card.tsx
@@ -1,0 +1,19 @@
+import clsx from "clsx";
+
+type Props = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default function Card({ children, className = "" }: Props) {
+  return (
+    <div
+      className={clsx(
+        "rounded-lg bg-bg-card text-gray-900 shadow-sm p-4",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/common/src/components/form/Input.tsx
+++ b/common/src/components/form/Input.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+type Props = React.InputHTMLAttributes<HTMLInputElement>;
+
+export default function Input(props: Props) {
+  return (
+    <input
+      {...props}
+      className={
+        "w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-600 focus:outline-none " +
+        (props.className || "")
+      }
+    />
+  );
+}

--- a/common/src/hooks/auth/AuthProvider.tsx
+++ b/common/src/hooks/auth/AuthProvider.tsx
@@ -1,0 +1,72 @@
+// manages { token, user }, persists to storage, exposes login/logout
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { LoginResponse, User } from "../../types/auth";
+import { login as apiLogin } from "../../lib/authApi";
+import { getJSON, setJSON, remove } from "../../lib/storage";
+
+type AuthContextValue = {
+  token: string | null;
+  user: User | null;
+  login: (u: string, p: string) => Promise<void>;
+  logout: () => void;
+  ready: boolean;
+};
+
+const AuthCtx = createContext<AuthContextValue | null>(null);
+
+type Props = {
+  children: React.ReactNode;
+  storageKey?: string; // per app (e.g., "admin_auth")
+};
+
+export function AuthProvider({ children, storageKey = "auth" }: Props) {
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const saved = getJSON<{ token: string; user: User }>("session", storageKey);
+    if (saved) {
+      setToken(saved.token);
+      setUser(saved.user);
+    }
+    setReady(true);
+  }, [storageKey]);
+
+  const login = async (username: string, password: string) => {
+    const data: LoginResponse = await apiLogin(username, password);
+    setToken(data.access_token);
+    setUser(data.user);
+    setJSON(
+      "session",
+      { token: data.access_token, user: data.user },
+      storageKey
+    );
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    remove("session", storageKey);
+  };
+
+  const value = useMemo(
+    () => ({ token, user, login, logout, ready }),
+    [token, user, ready]
+  );
+
+  return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthCtx);
+  if (!ctx) throw new Error("useAuth must be used within <AuthProvider>");
+  return ctx;
+}

--- a/common/src/hooks/auth/ProtectedRoute.tsx
+++ b/common/src/hooks/auth/ProtectedRoute.tsx
@@ -1,0 +1,14 @@
+// guards nested routes; accepts optional redirectTo="/login" prop
+
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "./AuthProvider";
+
+export default function ProtectedRoute({
+  redirectTo = "/login",
+}: {
+  redirectTo?: string;
+}) {
+  const { token, ready } = useAuth();
+  if (!ready) return null; // or loader
+  return token ? <Outlet /> : <Navigate to={redirectTo} replace />;
+}

--- a/common/src/hooks/auth/useAuth.ts
+++ b/common/src/hooks/auth/useAuth.ts
@@ -1,0 +1,1 @@
+// re-exported hook

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,5 +1,3 @@
-import Button from "./components/Button";
-
 // types
 export * from "./types/auth";
 
@@ -14,5 +12,5 @@ export { default as ProtectedRoute } from "./hooks/auth/ProtectedRoute";
 
 // components
 export * from "./components/form/Input";
-export * from "./components/form/Input";
 export * from "./components/Card";
+export * from "./components/Button";

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,0 +1,18 @@
+import Button from "./components/Button";
+
+// types
+export * from "./types/auth";
+
+// lib
+export * from "./lib/http";
+export * from "./lib/authApi";
+export * from "./lib/storage";
+
+// auth
+export { AuthProvider, useAuth } from "./hooks/auth/AuthProvider";
+export { default as ProtectedRoute } from "./hooks/auth/ProtectedRoute";
+
+// components
+export * from "./components/form/Input";
+export * from "./components/form/Input";
+export * from "./components/Card";

--- a/common/src/lib/authApi.ts
+++ b/common/src/lib/authApi.ts
@@ -1,0 +1,32 @@
+// login(username, password), me()
+
+// Keep it “pure” (no redirects), just return data/throw errors.
+
+// import { http } from "./http";
+// import type { LoginResponse } from "../types/auth";
+
+// export async function login(
+//   username: string,
+//   password: string
+// ): Promise<LoginResponse> {
+//  return http<LoginResponse>("/auth/login", {
+//    method: "POST",
+//    body: JSON.stringify({ username, password }),
+//  });
+// }
+
+// export async function me() {
+//   return http("/auth/me", { method: "GET" });
+// }
+
+// TEMP MOCK – remove once API is live
+export async function login(username: string, password: string) {
+  await new Promise((r) => setTimeout(r, 400));
+  if (username !== "demo" || password !== "demo") {
+    throw new Error("Invalid credentials");
+  }
+  return {
+    access_token: "fake-token",
+    user: { id: "u1", email: "admin@example.com", role: "admin" as const },
+  };
+}

--- a/common/src/lib/http.ts
+++ b/common/src/lib/http.ts
@@ -1,0 +1,29 @@
+// API base client (reads VITE_API_BASE_URL via a tiny getter you override per app)
+
+// Base HTTP helper with injectable base URL
+export type BaseUrlGetter = () => string;
+
+let getBaseUrl: BaseUrlGetter = () => {
+  throw new Error(
+    "Base URL getter not set. Call setBaseUrlGetter() from the app."
+  );
+};
+
+export function setBaseUrlGetter(fn: BaseUrlGetter) {
+  getBaseUrl = fn;
+}
+
+export async function http<T = unknown>(
+  path: string,
+  init?: RequestInit
+): Promise<T> {
+  const res = await fetch(`${getBaseUrl()}${path}`, {
+    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    throw new Error(msg || `${res.status} ${res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}

--- a/common/src/lib/storage.ts
+++ b/common/src/lib/storage.ts
@@ -1,0 +1,16 @@
+// localStorage helpers (get/set/remove with namespacing)
+
+const ns = (key: string, prefix = "auth") => `${prefix}:${key}`;
+
+export function setJSON(key: string, value: unknown, prefix?: string) {
+  localStorage.setItem(ns(key, prefix), JSON.stringify(value));
+}
+
+export function getJSON<T = unknown>(key: string, prefix?: string): T | null {
+  const raw = localStorage.getItem(ns(key, prefix));
+  return raw ? (JSON.parse(raw) as T) : null;
+}
+
+export function remove(key: string, prefix?: string) {
+  localStorage.removeItem(ns(key, prefix));
+}

--- a/common/src/lib/validation.ts
+++ b/common/src/lib/validation.ts
@@ -1,0 +1,1 @@
+// e.g., zod/yup schemas for login form

--- a/common/src/theme.css
+++ b/common/src/theme.css
@@ -1,0 +1,31 @@
+@layer base {
+  :root {
+    /* Brand colors */
+    --brand-primary: #2563eb;
+    --brand-secondary: #6b7280;
+
+    /* Semantic */
+    --semantic-success: #16a34a;
+    --semantic-warning: #f59e0b;
+    --semantic-error: #dc2626;
+    --semantic-info: #0284c7;
+
+    /* Backgrounds */
+    --bg-default: #f9fafb;
+    --bg-card: #ffffff;
+
+    /* Text */
+    --text-primary: #111827;
+    --text-secondary: #6b7280;
+    --text-on-dark: #ffffff;
+  }
+
+  .dark {
+    --bg-default: #111827;
+    --bg-card: #1f2937;
+
+    --text-primary: #f9fafb;
+    --text-secondary: #9ca3af;
+    --text-on-dark: #ffffff;
+  }
+}

--- a/common/src/types/auth.ts
+++ b/common/src/types/auth.ts
@@ -1,0 +1,12 @@
+export type Role = "admin" | "driver" | "customer";
+
+export type User = {
+  id: string;
+  email: string;
+  role: Role;
+};
+
+export type LoginResponse = {
+  access_token: string;
+  user: User;
+};

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true
+  }
+}


### PR DESCRIPTION
Follow-ups
- Replace mocked login with real POST /auth/login.
- Add Vitest tests for AuthProvider, ProtectedRoute, and common components.
- Refactor Button to use theme tokens (brand-primary, etc.) instead of hardcoded Tailwind colors.

What is done (sorry this is a bit random)
- Added LoginForm + LoginFormContainer with error + loading states.
- Token + user persisted via AuthProvider + useAuth.
- Implemented ProtectedRoute to guard admin routes.
- AppRouter now wraps routes with AuthProvider.
- New AdminLayout + TopNav with responsive navigation & logout.
- DashboardPage added, HomePage removed.
- Shared components (Button, Card, Input) created in common.
- File for theme (theme.css) defines brand, semantic, background, text colors.
- Shared utilities (common/)
- authApi (mocked login for now) + http client with setBaseUrlGetter.
- storage.ts (localStorage helpers).
- types/auth.ts (User, LoginResponse).
- mock-data/db.json for demo/testing.

Config & setup
- env.ts added for VITE_API_BASE_URL.
- main.tsx now calls setBaseUrlGetter(API_BASE_URL).
- tsconfig cleaned up with base + common references.
- index.css simplified and using Tailwind classes (does not work)

How to test
1. Start backend (or use mock login).
2. Run npm run dev in admin-frontend.
3. Navigate to /login.
4. Login with demo/demo.
5. Should redirect to / (Dashboard).
6. Protected routes (/shipments, /customers, /notifications) only work if logged in.
7. Logout from TopNav should clear token and redirect back to /login.