### PR TITLE
12.1.8 - Connect login flow to the real backend api instead of mock auth

### DIFF
--- a/admin-frontend/src/lib/env.ts
+++ b/admin-frontend/src/lib/env.ts
@@ -1,6 +1,4 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
 if (!API_BASE_URL) {
-  // Optional: warn in dev
-  // eslint-disable-next-line no-console
   console.warn("VITE_API_BASE_URL is not set");
 }

--- a/common/src/hooks/auth/useAuth.ts
+++ b/common/src/hooks/auth/useAuth.ts
@@ -1,1 +1,0 @@
-// re-exported hook

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -14,3 +14,4 @@ export { default as ProtectedRoute } from "./hooks/auth/ProtectedRoute";
 export { default as Button } from "./components/Button";
 export { default as Card } from "./components/Card";
 export { default as Input } from "./components/form/Input";
+export { ToggleTheme } from "./components/ThemeToggle";

--- a/common/src/lib/authApi.ts
+++ b/common/src/lib/authApi.ts
@@ -1,32 +1,28 @@
-// login(username, password), me()
+import { http } from "./http";
+import type { LoginResponse } from "../types/auth";
 
-// Keep it “pure” (no redirects), just return data/throw errors.
+export async function login(
+  username: string,
+  password: string
+): Promise<LoginResponse> {
+  return http<LoginResponse>("/api/v1/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ username, password }),
+  });
+}
 
-// import { http } from "./http";
-// import type { LoginResponse } from "../types/auth";
-
-// export async function login(
-//   username: string,
-//   password: string
-// ): Promise<LoginResponse> {
-//  return http<LoginResponse>("/auth/login", {
-//    method: "POST",
-//    body: JSON.stringify({ username, password }),
-//  });
-// }
-
-// export async function me() {
-//   return http("/auth/me", { method: "GET" });
-// }
+export async function me() {
+  return http("/api/v1/auth/me", { method: "GET" });
+}
 
 // TEMP MOCK – remove once API is live
-export async function login(username: string, password: string) {
-  await new Promise((r) => setTimeout(r, 400));
-  if (username !== "demo" || password !== "demo") {
-    throw new Error("Invalid credentials");
-  }
-  return {
-    access_token: "fake-token",
-    user: { id: "u1", email: "admin@example.com", role: "admin" as const },
-  };
-}
+// export async function login(username: string, password: string) {
+//  await new Promise((r) => setTimeout(r, 400));
+//  if (username !== "demo" || password !== "demo") {
+//    throw new Error("Invalid credentials");
+//  }
+//  return {
+//    access_token: "fake-token",
+//    user: { id: "u1", email: "admin@example.com", role: "admin" as const },
+//  };
+// }

--- a/common/src/lib/http.ts
+++ b/common/src/lib/http.ts
@@ -17,10 +17,17 @@ export async function http<T = unknown>(
   path: string,
   init?: RequestInit
 ): Promise<T> {
+  const token = localStorage.getItem("access_token"); // <-- get JWT
+
   const res = await fetch(`${getBaseUrl()}${path}`, {
-    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}), // <-- adds token automatically
+      ...(init?.headers || {}),
+    },
     ...init,
   });
+
   if (!res.ok) {
     const msg = await res.text().catch(() => "");
     throw new Error(msg || `${res.status} ${res.statusText}`);


### PR DESCRIPTION
**Overview**
This PR connects the frontend with the real backend for authentication.

**Changes**
- Replaced mock login with real API call to /api/v1/auth/login.
- Added VITE_API_BASE_URL and base URL getter setup.
- Updated AuthProvider to save token + user from backend.
- Enabled CORS so frontend can talk to backend.

**Result**
Login now works end-to-end: frontend → backend → JWT → protected routes. 🎉

Note: You can still use the mock when working on the apps. In frontend/common/src/lib/authApi.tsx, comment out the existing code and switch to the already-commented mock part.