### PR TITLE
12.1.8 - Connect login flow to the real backend api instead of mock auth

### DIFF
--- a/common/src/hooks/auth/AuthProvider.tsx
+++ b/common/src/hooks/auth/AuthProvider.tsx
@@ -1,72 +1,90 @@
 // manages { token, user }, persists to storage, exposes login/logout
 
 import React, {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
+	createContext,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
 } from "react";
 import type { LoginResponse, User } from "../../types/auth";
 import { login as apiLogin } from "../../lib/authApi";
 import { getJSON, setJSON, remove } from "../../lib/storage";
+import { jwtDecode } from "jwt-decode";
 
 type AuthContextValue = {
-  token: string | null;
-  user: User | null;
-  login: (u: string, p: string) => Promise<void>;
-  logout: () => void;
-  ready: boolean;
+	token: string | null;
+	user: User | null;
+	login: (u: string, p: string) => Promise<void>;
+	logout: () => void;
+	ready: boolean;
+};
+
+type JwtPayload = {
+	exp: number;
+	iat?: number;
+	sub?: string;
 };
 
 const AuthCtx = createContext<AuthContextValue | null>(null);
 
 type Props = {
-  children: React.ReactNode;
-  storageKey?: string; // per app (e.g., "admin_auth")
+	children: React.ReactNode;
+	storageKey?: string; // per app (e.g., "admin_auth")
 };
 
+function isTokenValid(token: string): boolean {
+	try {
+		const { exp } = jwtDecode<JwtPayload>(token);
+		return Date.now() < exp * 1000;
+	} catch {
+		return false;
+	}
+}
+
 export function AuthProvider({ children, storageKey = "auth" }: Props) {
-  const [token, setToken] = useState<string | null>(null);
-  const [user, setUser] = useState<User | null>(null);
-  const [ready, setReady] = useState(false);
+	const [token, setToken] = useState<string | null>(null);
+	const [user, setUser] = useState<User | null>(null);
+	const [ready, setReady] = useState(false);
 
-  useEffect(() => {
-    const saved = getJSON<{ token: string; user: User }>("session", storageKey);
-    if (saved) {
-      setToken(saved.token);
-      setUser(saved.user);
-    }
-    setReady(true);
-  }, [storageKey]);
+	useEffect(() => {
+		const saved = getJSON<{ token: string; user: User }>("session", storageKey);
+		if (saved && isTokenValid(saved.token)) {
+			setToken(saved.token);
+			setUser(saved.user);
+		} else {
+			remove("session", storageKey);
+		}
+		setReady(true);
+	}, [storageKey]);
 
-  const login = async (username: string, password: string) => {
-    const data: LoginResponse = await apiLogin(username, password);
-    setToken(data.access_token);
-    setUser(data.user);
-    setJSON(
-      "session",
-      { token: data.access_token, user: data.user },
-      storageKey
-    );
-  };
+	const login = async (username: string, password: string) => {
+		const data: LoginResponse = await apiLogin(username, password);
+		setToken(data.access_token);
+		setUser(data.user);
+		setJSON(
+			"session",
+			{ token: data.access_token, user: data.user },
+			storageKey
+		);
+	};
 
-  const logout = () => {
-    setToken(null);
-    setUser(null);
-    remove("session", storageKey);
-  };
+	const logout = () => {
+		setToken(null);
+		setUser(null);
+		remove("session", storageKey);
+	};
 
-  const value = useMemo(
-    () => ({ token, user, login, logout, ready }),
-    [token, user, ready]
-  );
+	const value = useMemo(
+		() => ({ token, user, login, logout, ready }),
+		[token, user, ready]
+	);
 
-  return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>;
+	return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>;
 }
 
 export function useAuth() {
-  const ctx = useContext(AuthCtx);
-  if (!ctx) throw new Error("useAuth must be used within <AuthProvider>");
-  return ctx;
+	const ctx = useContext(AuthCtx);
+	if (!ctx) throw new Error("useAuth must be used within <AuthProvider>");
+	return ctx;
 }

--- a/common/src/hooks/auth/ProtectedRoute.tsx
+++ b/common/src/hooks/auth/ProtectedRoute.tsx
@@ -1,14 +1,12 @@
-// guards nested routes; accepts optional redirectTo="/login" prop
-
 import { Navigate, Outlet } from "react-router-dom";
 import { useAuth } from "./AuthProvider";
 
 export default function ProtectedRoute({
-  redirectTo = "/login",
+	redirectTo = "/login",
 }: {
-  redirectTo?: string;
+	redirectTo?: string;
 }) {
-  const { token, ready } = useAuth();
-  if (!ready) return null; // or loader
-  return token ? <Outlet /> : <Navigate to={redirectTo} replace />;
+	const { token, ready } = useAuth();
+	if (!ready) return null; // or loader
+	return token ? <Outlet /> : <Navigate to={redirectTo} replace />;
 }

--- a/common/src/lib/authApi.ts
+++ b/common/src/lib/authApi.ts
@@ -1,18 +1,23 @@
 import { http } from "./http";
-import type { LoginResponse } from "../types/auth";
+import type { LoginResponse, User } from "../types/auth";
 
+// Login returns JWT + user info
 export async function login(
-  username: string,
-  password: string
+	username: string,
+	password: string
 ): Promise<LoginResponse> {
-  return http<LoginResponse>("/api/v1/auth/login", {
-    method: "POST",
-    body: JSON.stringify({ username, password }),
-  });
+	return http<LoginResponse>("/api/v1/auth/login", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ username, password }),
+	});
 }
 
-export async function me() {
-  return http("/api/v1/auth/me", { method: "GET" });
+// Me fetches the current logged-in user
+export async function me(): Promise<User> {
+	return http<User>("/api/v1/auth/me", { method: "GET" });
 }
 
 // TEMP MOCK – remove once API is live

--- a/common/src/lib/http.ts
+++ b/common/src/lib/http.ts
@@ -4,33 +4,44 @@
 export type BaseUrlGetter = () => string;
 
 let getBaseUrl: BaseUrlGetter = () => {
-  throw new Error(
-    "Base URL getter not set. Call setBaseUrlGetter() from the app."
-  );
+	throw new Error(
+		"Base URL getter not set. Call setBaseUrlGetter() from the app."
+	);
 };
 
 export function setBaseUrlGetter(fn: BaseUrlGetter) {
-  getBaseUrl = fn;
+	getBaseUrl = fn;
 }
 
 export async function http<T = unknown>(
-  path: string,
-  init?: RequestInit
+	path: string,
+	init: RequestInit = {}
 ): Promise<T> {
-  const token = localStorage.getItem("access_token"); // <-- get JWT
+	const token = localStorage.getItem("access_token"); // get JWT
 
-  const res = await fetch(`${getBaseUrl()}${path}`, {
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}), // <-- adds token automatically
-      ...(init?.headers || {}),
-    },
-    ...init,
-  });
+	const res = await fetch(`${getBaseUrl()}${path}`, {
+		...init,
+		headers: {
+			"Content-Type": "application/json",
+			...(token ? { Authorization: `Bearer ${token}` } : {}),
+			...(init.headers || {}), // <-- merge user headers last (allows override)
+		},
+	});
 
-  if (!res.ok) {
-    const msg = await res.text().catch(() => "");
-    throw new Error(msg || `${res.status} ${res.statusText}`);
-  }
-  return res.json() as Promise<T>;
+	if (!res.ok) {
+		let msg: string;
+		try {
+			msg = (await res.json()).detail ?? (await res.text());
+		} catch {
+			msg = `${res.status} ${res.statusText}`;
+		}
+		throw new Error(msg);
+	}
+
+	// Handle empty responses (e.g. DELETE 204 No Content)
+	if (res.status === 204) {
+		return undefined as T;
+	}
+
+	return res.json() as Promise<T>;
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/Chas-Advance-Grupp-4/frontend#readme",
   "dependencies": {
     "@tailwindcss/vite": "^4.1.13",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.544.0",
     "tailwindcss": "^4.1.13"
   }


### PR DESCRIPTION
Just wanted to make sure everything was done correctly in this task before starting the next one. Also added jwt-decode that decodes the JWT and verifies it before restoring it in useEffect.